### PR TITLE
アカウント削除時にログアウト状態、いいねの記録を削除

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,10 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    User.find(params[:id]).destroy
+    @user = User.find(params[:id])
+    @user.likes.destroy_all
+    @user.destroy
+    reset_session
     flash[:success] = "アカウントを削除しました"
     redirect_to root_path, status: :see_other
   end


### PR DESCRIPTION
#31 
原因：reset_sessionしていなかった

#42 
原因：@user.likes.destroy_allしていなかった

のIssueを完了